### PR TITLE
feat: removing s3 async client and adding aal vector path

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
@@ -98,7 +98,6 @@ import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.identity.spi.AwsSessionCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ServiceClientConfiguration;
 import software.amazon.awssdk.services.s3.model.BucketAlreadyExistsException;
@@ -507,17 +506,13 @@ public class TestS3FileIO {
     io.initialize(Map.of(AwsClientProperties.CLIENT_REGION, "us-east-1"));
 
     assertThat(io.client()).isInstanceOf(S3Client.class);
-    assertThat(io.asyncClient()).isInstanceOf(S3AsyncClient.class);
     assertThat(io.client("s3a://my-bucket/my-path")).isInstanceOf(S3Client.class);
-    assertThat(io.asyncClient("s3a://my-bucket/my-path")).isInstanceOf(S3AsyncClient.class);
 
     S3FileIO fileIO = roundTripSerializer.apply(io);
     assertThat(fileIO.credentials()).isEqualTo(io.credentials()).isEmpty();
 
     assertThat(fileIO.client()).isInstanceOf(S3Client.class);
-    assertThat(fileIO.asyncClient()).isInstanceOf(S3AsyncClient.class);
     assertThat(fileIO.client("s3a://my-bucket/my-path")).isInstanceOf(S3Client.class);
-    assertThat(fileIO.asyncClient("s3a://my-bucket/my-path")).isInstanceOf(S3AsyncClient.class);
   }
 
   @ParameterizedTest
@@ -533,18 +528,14 @@ public class TestS3FileIO {
 
     // there should be a client for the generic and specific storage prefix available
     assertThat(io.client()).isInstanceOf(S3Client.class);
-    assertThat(io.asyncClient()).isInstanceOf(S3AsyncClient.class);
     assertThat(io.client("s3://my-bucket/my-path")).isInstanceOf(S3Client.class);
-    assertThat(io.asyncClient("s3://my-bucket/my-path")).isInstanceOf(S3AsyncClient.class);
 
     S3FileIO fileIO = roundTripSerializer.apply(io);
     assertThat(fileIO.credentials()).isEqualTo(io.credentials());
 
     // make sure there's a client for the generic and specific storage prefix available after ser/de
     assertThat(fileIO.client()).isInstanceOf(S3Client.class);
-    assertThat(fileIO.asyncClient()).isInstanceOf(S3AsyncClient.class);
     assertThat(fileIO.client("s3://my-bucket/my-path")).isInstanceOf(S3Client.class);
-    assertThat(fileIO.asyncClient("s3://my-bucket/my-path")).isInstanceOf(S3AsyncClient.class);
   }
 
   @Test
@@ -641,9 +632,6 @@ public class TestS3FileIO {
               assertThat(fileIO.client("s3://foo/bar"))
                   .isSameAs(fileIO.client())
                   .isInstanceOf(S3Client.class);
-              assertThat(fileIO.asyncClient("s3://foo/bar"))
-                  .isSameAs(fileIO.asyncClient())
-                  .isInstanceOf(S3AsyncClient.class);
             });
 
     // make sure credentials can be accessed after serde
@@ -662,9 +650,6 @@ public class TestS3FileIO {
               assertThat(fileIO.client("s3://foo/bar"))
                   .isSameAs(fileIO.client())
                   .isInstanceOf(S3Client.class);
-              assertThat(fileIO.asyncClient("s3://foo/bar"))
-                  .isSameAs(fileIO.asyncClient())
-                  .isInstanceOf(S3AsyncClient.class);
             });
   }
 
@@ -696,9 +681,6 @@ public class TestS3FileIO {
           assertThat(fileIO.client("s3://foo/bar"))
               .isNotSameAs(fileIO.client())
               .isInstanceOf(S3Client.class);
-          assertThat(fileIO.asyncClient("s3://foo/bar"))
-              .isNotSameAs(fileIO.asyncClient())
-              .isInstanceOf(S3AsyncClient.class);
         });
 
     // make sure credentials are still present after serde
@@ -721,9 +703,6 @@ public class TestS3FileIO {
           assertThat(fileIO.client("s3://foo/bar"))
               .isNotSameAs(fileIO.client())
               .isInstanceOf(S3Client.class);
-          assertThat(fileIO.asyncClient("s3://foo/bar"))
-              .isNotSameAs(fileIO.asyncClient())
-              .isInstanceOf(S3AsyncClient.class);
         });
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -28,8 +28,6 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.kms.KmsClient;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
 import software.amazon.awssdk.services.sts.StsClient;
@@ -53,26 +51,6 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
         .applyMutation(s3FileIOProperties::applyServiceConfigurations)
         .applyMutation(s3FileIOProperties::applySignerConfiguration)
         .applyMutation(s3FileIOProperties::applyRetryConfigurations)
-        .build();
-  }
-
-  @Override
-  public S3AsyncClient s3Async() {
-    if (s3FileIOProperties.isS3CRTEnabled()) {
-      return S3AsyncClient.crtBuilder()
-          .applyMutation(this::applyAssumeRoleConfigurations)
-          .applyMutation(awsClientProperties::applyClientRegionConfiguration)
-          .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
-          .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
-          .applyMutation(s3FileIOProperties::applyS3CrtConfigurations)
-          .build();
-    }
-    return S3AsyncClient.builder()
-        .applyMutation(this::applyAssumeRoleConfigurations)
-        .applyMutation(awsClientProperties::applyClientRegionConfiguration)
-        .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
-        .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
-        .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
         .build();
   }
 
@@ -123,12 +101,6 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
         .credentialsProvider(createCredentialsProvider())
         .region(Region.of(awsProperties.clientAssumeRoleRegion()));
     return clientBuilder;
-  }
-
-  protected S3AsyncClientBuilder applyAssumeRoleConfigurations(S3AsyncClientBuilder clientBuilder) {
-    return clientBuilder
-        .credentialsProvider(createCredentialsProvider())
-        .region(Region.of(awsProperties.clientAssumeRoleRegion()));
   }
 
   protected S3CrtAsyncClientBuilder applyAssumeRoleConfigurations(

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -39,7 +39,6 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.glue.GlueClientBuilder;
 import software.amazon.awssdk.services.kms.KmsClient;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3BaseClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -117,26 +116,6 @@ public class AwsClientFactories {
           .applyMutation(s3FileIOProperties::applyS3AccessGrantsConfigurations)
           .applyMutation(s3FileIOProperties::applyUserAgentConfigurations)
           .applyMutation(s3FileIOProperties::applyRetryConfigurations)
-          .build();
-    }
-
-    @Override
-    public S3AsyncClient s3Async() {
-      if (s3FileIOProperties.isS3CRTEnabled()) {
-        return S3AsyncClient.crtBuilder()
-            .applyMutation(awsClientProperties::applyClientRegionConfiguration)
-            .applyMutation(
-                b -> s3FileIOProperties.applyCredentialConfigurations(awsClientProperties, b))
-            .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
-            .applyMutation(s3FileIOProperties::applyS3CrtConfigurations)
-            .build();
-      }
-      return S3AsyncClient.builder()
-          .applyMutation(awsClientProperties::applyClientRegionConfiguration)
-          .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
-          .applyMutation(
-              b -> s3FileIOProperties.applyCredentialConfigurations(awsClientProperties, b))
-          .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
           .build();
     }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactory.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.kms.KmsClient;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 /**
@@ -38,13 +37,6 @@ public interface AwsClientFactory extends Serializable {
    * @return s3 client
    */
   S3Client s3();
-
-  /**
-   * create a Amazon S3 async client
-   *
-   * @return s3 async client
-   */
-  S3AsyncClient s3Async();
 
   /**
    * create a AWS Glue client

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
@@ -39,7 +39,6 @@ import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.LegacyMd5Plugin;
-import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
 
 public class AwsClientProperties implements Serializable {
   /**
@@ -149,21 +148,6 @@ public class AwsClientProperties implements Serializable {
   }
 
   /**
-   * Configure an S3 CRT client region.
-   *
-   * <p>Sample usage:
-   *
-   * <pre>
-   *     S3AsyncClient.crtBuilder().applyMutation(awsClientProperties::applyClientRegionConfiguration)
-   * </pre>
-   */
-  public <T extends S3CrtAsyncClientBuilder> void applyClientRegionConfiguration(T builder) {
-    if (clientRegion != null) {
-      builder.region(Region.of(clientRegion));
-    }
-  }
-
-  /**
    * Configure the credential provider for AWS clients.
    *
    * <p>Sample usage:
@@ -174,21 +158,6 @@ public class AwsClientProperties implements Serializable {
    */
   public <BuilderT extends AwsClientBuilder<BuilderT, ClientT>, ClientT>
       void applyClientCredentialConfigurations(BuilderT builder) {
-    if (!Strings.isNullOrEmpty(this.clientCredentialsProvider)) {
-      builder.credentialsProvider(credentialsProvider(this.clientCredentialsProvider));
-    }
-  }
-
-  /**
-   * Configure the credential provider for S3 CRT clients.
-   *
-   * <p>Sample usage:
-   *
-   * <pre>
-   *     S3AsyncClient.crtBuilder().applyMutation(awsClientProperties::applyClientCredentialConfigurations)
-   * </pre>
-   */
-  public <T extends S3CrtAsyncClientBuilder> void applyClientCredentialConfigurations(T builder) {
     if (!Strings.isNullOrEmpty(this.clientCredentialsProvider)) {
       builder.credentialsProvider(credentialsProvider(this.clientCredentialsProvider));
     }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorInputStreamWrapper.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorInputStreamWrapper.java
@@ -19,31 +19,68 @@
 package org.apache.iceberg.aws.s3;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+import org.apache.iceberg.io.FileIOMetricsContext;
+import org.apache.iceberg.io.FileRange;
+import org.apache.iceberg.io.RangeReadable;
 import org.apache.iceberg.io.SeekableInputStream;
+import org.apache.iceberg.metrics.Counter;
+import org.apache.iceberg.metrics.MetricsContext;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStream;
+import software.amazon.s3.analyticsaccelerator.common.ObjectRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** A wrapper to convert {@link S3SeekableInputStream} to Iceberg {@link SeekableInputStream} */
-class AnalyticsAcceleratorInputStreamWrapper extends SeekableInputStream {
+class AnalyticsAcceleratorInputStreamWrapper extends SeekableInputStream implements RangeReadable {
+  private static final Logger LOG =
+          LoggerFactory.getLogger(AnalyticsAcceleratorInputStreamWrapper.class);
 
   private final S3SeekableInputStream delegate;
+  private final Counter readBytes;
+  private final Counter readOperations;
 
   AnalyticsAcceleratorInputStreamWrapper(S3SeekableInputStream stream) {
+    this(stream, MetricsContext.nullMetrics());
+  }
+
+  AnalyticsAcceleratorInputStreamWrapper(S3SeekableInputStream stream, MetricsContext metrics) {
     this.delegate = stream;
+    this.readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES, MetricsContext.Unit.BYTES);
+    this.readOperations = metrics.counter(FileIOMetricsContext.READ_OPERATIONS);
   }
 
   @Override
   public int read() throws IOException {
-    return this.delegate.read();
-  }
-
-  @Override
-  public int read(byte[] b) throws IOException {
-    return this.delegate.read(b, 0, b.length);
+    int nextByteValue = this.delegate.read();
+    if (nextByteValue != -1) {
+      readBytes.increment();
+    }
+    readOperations.increment();
+    return nextByteValue;
   }
 
   @Override
   public int read(byte[] b, int off, int len) throws IOException {
-    return this.delegate.read(b, off, len);
+    int bytesRead = this.delegate.read(b, off, len);
+    if (bytesRead > 0) {
+      readBytes.increment(bytesRead);
+    }
+    readOperations.increment();
+    return bytesRead;
+  }
+
+  @Override
+  public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {
+    this.delegate.readFully(position, buffer, offset, length);
+  }
+
+  @Override
+  public int readTail(byte[] buffer, int offset, int length) throws IOException {
+    return this.delegate.readTail(buffer, offset, length);
   }
 
   @Override
@@ -54,6 +91,21 @@ class AnalyticsAcceleratorInputStreamWrapper extends SeekableInputStream {
   @Override
   public long getPos() {
     return this.delegate.getPos();
+  }
+
+  @Override
+  public void readVectored(List<FileRange> ranges, IntFunction<ByteBuffer> allocate) throws IOException {
+    List<ObjectRange> objectRanges = ranges.stream()
+            .map(
+                    range ->
+                            new software.amazon.s3.analyticsaccelerator.common.ObjectRange(
+                                    range.byteBuffer(), range.offset(), range.length()))
+            .collect(Collectors.toList());
+
+    // This does not keep track of bytes read and that is a possible improvement.
+    readOperations.increment();
+    this.delegate.readVectored(objectRanges, allocate,
+            buffer -> LOG.info("Release buffer of length {}: {}", buffer.limit(), buffer));
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.aws.s3;
 
 import org.apache.iceberg.metrics.MetricsContext;
 import software.amazon.awssdk.http.HttpStatusCode;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
@@ -28,20 +27,14 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 
 abstract class BaseS3File {
   private final S3Client client;
-  private final S3AsyncClient asyncClient;
   private final S3URI uri;
   private final S3FileIOProperties s3FileIOProperties;
   private HeadObjectResponse metadata;
   private final MetricsContext metrics;
 
   BaseS3File(
-      S3Client client,
-      S3AsyncClient asyncClient,
-      S3URI uri,
-      S3FileIOProperties s3FileIOProperties,
-      MetricsContext metrics) {
+      S3Client client, S3URI uri, S3FileIOProperties s3FileIOProperties, MetricsContext metrics) {
     this.client = client;
-    this.asyncClient = asyncClient;
     this.uri = uri;
     this.s3FileIOProperties = s3FileIOProperties;
     this.metrics = metrics;
@@ -53,10 +46,6 @@ abstract class BaseS3File {
 
   S3Client client() {
     return client;
-  }
-
-  S3AsyncClient asyncClient() {
-    return asyncClient;
   }
 
   S3URI uri() {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.aws.s3;
 import java.util.Map;
 import org.apache.iceberg.aws.AwsClientProperties;
 import org.apache.iceberg.aws.HttpClientProperties;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
@@ -58,24 +57,6 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
         .applyMutation(s3FileIOProperties::applyS3AccessGrantsConfigurations)
         .applyMutation(s3FileIOProperties::applyUserAgentConfigurations)
         .applyMutation(s3FileIOProperties::applyRetryConfigurations)
-        .build();
-  }
-
-  @Override
-  public S3AsyncClient s3Async() {
-    if (s3FileIOProperties.isS3CRTEnabled()) {
-      return S3AsyncClient.crtBuilder()
-          .applyMutation(awsClientProperties::applyClientRegionConfiguration)
-          .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
-          .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
-          .applyMutation(s3FileIOProperties::applyS3CrtConfigurations)
-          .build();
-    }
-    return S3AsyncClient.builder()
-        .applyMutation(awsClientProperties::applyClientRegionConfiguration)
-        .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
-        .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
-        .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
         .build();
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/PrefixedS3Client.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/PrefixedS3Client.java
@@ -24,7 +24,6 @@ import org.apache.iceberg.aws.S3FileIOAwsClientFactories;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.util.SerializableSupplier;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 class PrefixedS3Client implements AutoCloseable {
@@ -32,21 +31,15 @@ class PrefixedS3Client implements AutoCloseable {
   private final String storagePrefix;
   private final S3FileIOProperties s3FileIOProperties;
   private SerializableSupplier<S3Client> s3;
-  private SerializableSupplier<S3AsyncClient> s3Async;
   private transient volatile S3Client s3Client;
-  private transient volatile S3AsyncClient s3AsyncClient;
 
   PrefixedS3Client(
-      String storagePrefix,
-      Map<String, String> properties,
-      SerializableSupplier<S3Client> s3,
-      SerializableSupplier<S3AsyncClient> s3Async) {
+      String storagePrefix, Map<String, String> properties, SerializableSupplier<S3Client> s3) {
     Preconditions.checkArgument(
         !Strings.isNullOrEmpty(storagePrefix), "Invalid storage prefix: null or empty");
     Preconditions.checkArgument(null != properties, "Invalid properties: null");
     this.storagePrefix = storagePrefix;
     this.s3 = s3;
-    this.s3Async = s3Async;
     this.s3FileIOProperties = new S3FileIOProperties(properties);
     // Do not override s3 client if it was provided
     if (s3 == null) {
@@ -59,17 +52,6 @@ class PrefixedS3Client implements AutoCloseable {
       }
       if (s3FileIOProperties.isPreloadClientEnabled()) {
         s3();
-      }
-    }
-
-    // Do not override s3Async client if it was provided
-    if (s3Async == null) {
-      Object clientFactory = S3FileIOAwsClientFactories.initialize(properties);
-      if (clientFactory instanceof S3FileIOAwsClientFactory) {
-        this.s3Async = ((S3FileIOAwsClientFactory) clientFactory)::s3Async;
-      }
-      if (clientFactory instanceof AwsClientFactory) {
-        this.s3Async = ((AwsClientFactory) clientFactory)::s3Async;
       }
     }
   }
@@ -90,18 +72,6 @@ class PrefixedS3Client implements AutoCloseable {
     return s3Client;
   }
 
-  public S3AsyncClient s3Async() {
-    if (s3AsyncClient == null) {
-      synchronized (this) {
-        if (s3AsyncClient == null) {
-          s3AsyncClient = s3Async.get();
-        }
-      }
-    }
-
-    return s3AsyncClient;
-  }
-
   public S3FileIOProperties s3FileIOProperties() {
     return s3FileIOProperties;
   }
@@ -109,15 +79,11 @@ class PrefixedS3Client implements AutoCloseable {
   @Override
   public void close() {
     if (null != s3Client) {
-      s3Client.close();
-    }
-
-    if (null != s3AsyncClient) {
       // cleanup usage in analytics accelerator if any
       if (s3FileIOProperties().isS3AnalyticsAcceleratorEnabled()) {
-        AnalyticsAcceleratorUtil.cleanupCache(s3AsyncClient, s3FileIOProperties);
+        AnalyticsAcceleratorUtil.cleanupCache(s3Client, s3FileIOProperties);
       }
-      s3AsyncClient.close();
+      s3Client.close();
     }
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -61,7 +61,6 @@ import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.exception.SdkException;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.Delete;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
@@ -98,7 +97,6 @@ public class S3FileIO
 
   private String credential = null;
   private SerializableSupplier<S3Client> s3;
-  private SerializableSupplier<S3AsyncClient> s3Async;
   private SerializableMap<String, String> properties = null;
   private MetricsContext metrics = MetricsContext.nullMetrics();
   private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
@@ -122,20 +120,7 @@ public class S3FileIO
    * @param s3 s3 supplier
    */
   public S3FileIO(SerializableSupplier<S3Client> s3) {
-    this(s3, null);
-  }
-
-  /**
-   * Constructor with custom s3 supplier and s3Async supplier.
-   *
-   * <p>Calling {@link S3FileIO#initialize(Map)} will overwrite information set in this constructor.
-   *
-   * @param s3 s3 supplier
-   * @param s3Async s3Async supplier
-   */
-  public S3FileIO(SerializableSupplier<S3Client> s3, SerializableSupplier<S3AsyncClient> s3Async) {
     this.s3 = s3;
-    this.s3Async = s3Async;
     this.createStack = Thread.currentThread().getStackTrace();
     this.properties = SerializableMap.copyOf(Maps.newHashMap());
   }
@@ -367,15 +352,6 @@ public class S3FileIO
     return clientForStoragePath(storagePath).s3();
   }
 
-  public S3AsyncClient asyncClient() {
-    return asyncClient(ROOT_PREFIX);
-  }
-
-  @SuppressWarnings("resource")
-  public S3AsyncClient asyncClient(String storagePath) {
-    return clientForStoragePath(storagePath).s3Async();
-  }
-
   @VisibleForTesting
   PrefixedS3Client clientForStoragePath(String storagePath) {
     PrefixedS3Client client;
@@ -401,8 +377,7 @@ public class S3FileIO
         if (null == clientByPrefix) {
           Map<String, PrefixedS3Client> localClientByPrefix = Maps.newHashMap();
 
-          localClientByPrefix.put(
-              ROOT_PREFIX, new PrefixedS3Client(ROOT_PREFIX, properties, s3, s3Async));
+          localClientByPrefix.put(ROOT_PREFIX, new PrefixedS3Client(ROOT_PREFIX, properties, s3));
           storageCredentials.stream()
               .filter(c -> c.prefix().startsWith(ROOT_PREFIX))
               .collect(Collectors.toList())
@@ -417,7 +392,7 @@ public class S3FileIO
                     localClientByPrefix.put(
                         storageCredential.prefix(),
                         new PrefixedS3Client(
-                            storageCredential.prefix(), propertiesWithCredentials, s3, s3Async));
+                            storageCredential.prefix(), propertiesWithCredentials, s3));
                   });
           this.clientByPrefix = localClientByPrefix;
         }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOAwsClientFactory.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.aws.s3;
 
 import java.io.Serializable;
 import java.util.Map;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public interface S3FileIOAwsClientFactory extends Serializable {
@@ -30,13 +29,6 @@ public interface S3FileIOAwsClientFactory extends Serializable {
    * @return s3 client
    */
   S3Client s3();
-
-  /**
-   * create a Amazon S3 async client
-   *
-   * @return s3 async client
-   */
-  S3AsyncClient s3Async();
 
   /**
    * Initialize AWS client factory from catalog properties.

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -1021,31 +1021,15 @@ public class S3FileIOProperties implements Serializable {
   }
 
   /**
-   * Override the endpoint for an S3 sync or async client.
+   * Override the endpoint for an S3 sync client.
    *
    * <p>Sample usage:
    *
    * <pre>
    *     S3Client.builder().applyMutation(s3FileIOProperties::applyEndpointConfigurations)
-   *     S3AsyncClient.builder().applyMutation(s3FileIOProperties::applyEndpointConfigurations)
    * </pre>
    */
   public <T extends S3BaseClientBuilder<T, ?>> void applyEndpointConfigurations(T builder) {
-    if (endpoint != null) {
-      builder.endpointOverride(URI.create(endpoint));
-    }
-  }
-
-  /**
-   * Override the endpoint for an S3 CRT client
-   *
-   * <p>Sample usage:
-   *
-   * <pre>
-   *     S3AsyncClient.crtBuilder().applyMutation(s3FileIOProperties::applyEndpointConfigurations)
-   * </pre>
-   */
-  public <T extends S3CrtAsyncClientBuilder> void applyEndpointConfigurations(T builder) {
     if (endpoint != null) {
       builder.endpointOverride(URI.create(endpoint));
     }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
@@ -23,7 +23,6 @@ import org.apache.iceberg.encryption.NativelyEncryptedFile;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.MetricsContext;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class S3InputFile extends BaseS3File implements InputFile, NativelyEncryptedFile {
@@ -39,7 +38,6 @@ public class S3InputFile extends BaseS3File implements InputFile, NativelyEncryp
       String location, long length, PrefixedS3Client client, MetricsContext metrics) {
     return new S3InputFile(
         client.s3(),
-        client.s3FileIOProperties().isS3AnalyticsAcceleratorEnabled() ? client.s3Async() : null,
         new S3URI(location, client.s3FileIOProperties().bucketToAccessPointMapping()),
         length > 0 ? length : null,
         client.s3FileIOProperties(),
@@ -48,12 +46,11 @@ public class S3InputFile extends BaseS3File implements InputFile, NativelyEncryp
 
   S3InputFile(
       S3Client client,
-      S3AsyncClient asyncClient,
       S3URI uri,
       Long length,
       S3FileIOProperties s3FileIOProperties,
       MetricsContext metrics) {
-    super(client, asyncClient, uri, s3FileIOProperties, metrics);
+    super(client, uri, s3FileIOProperties, metrics);
     this.length = length;
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.metrics.MetricsContext;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class S3OutputFile extends BaseS3File implements OutputFile, NativelyEncryptedFile {
@@ -37,19 +36,14 @@ public class S3OutputFile extends BaseS3File implements OutputFile, NativelyEncr
       String location, PrefixedS3Client client, MetricsContext metrics) {
     return new S3OutputFile(
         client.s3(),
-        client.s3FileIOProperties().isS3AnalyticsAcceleratorEnabled() ? client.s3Async() : null,
         new S3URI(location, client.s3FileIOProperties().bucketToAccessPointMapping()),
         client.s3FileIOProperties(),
         metrics);
   }
 
   S3OutputFile(
-      S3Client client,
-      S3AsyncClient asyncClient,
-      S3URI uri,
-      S3FileIOProperties s3FileIOProperties,
-      MetricsContext metrics) {
-    super(client, asyncClient, uri, s3FileIOProperties, metrics);
+      S3Client client, S3URI uri, S3FileIOProperties s3FileIOProperties, MetricsContext metrics) {
+    super(client, uri, s3FileIOProperties, metrics);
   }
 
   /**
@@ -78,7 +72,7 @@ public class S3OutputFile extends BaseS3File implements OutputFile, NativelyEncr
 
   @Override
   public InputFile toInputFile() {
-    return new S3InputFile(client(), asyncClient(), uri(), null, s3FileIOProperties(), metrics());
+    return new S3InputFile(client(), uri(), null, s3FileIOProperties(), metrics());
   }
 
   @Override

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
@@ -28,7 +28,6 @@ import org.apache.iceberg.aws.lakeformation.LakeFormationAwsClientFactory;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.SerializationUtil;
 import org.assertj.core.api.ThrowableAssert;
@@ -43,9 +42,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.glue.model.GetTablesRequest;
 import software.amazon.awssdk.services.kms.KmsClient;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.internal.crt.DefaultS3CrtAsyncClient;
 
 public class TestAwsClientFactories {
 
@@ -58,55 +55,6 @@ public class TestAwsClientFactories {
     assertThat(AwsClientFactories.from(Maps.newHashMap()))
         .as("should load default when not configured")
         .isInstanceOf(AwsClientFactories.DefaultAwsClientFactory.class);
-  }
-
-  @Test
-  public void testS3AsyncClientCrtEnabled() {
-    assertThat(
-            AwsClientFactories.from(
-                    ImmutableMap.of(
-                        S3FileIOProperties.ACCESS_KEY_ID,
-                        "keyId",
-                        S3FileIOProperties.SECRET_ACCESS_KEY,
-                        "accessKey",
-                        S3FileIOProperties.S3_CRT_ENABLED,
-                        "true",
-                        AwsClientProperties.CLIENT_REGION,
-                        "us-east-1"))
-                .s3Async())
-        .isInstanceOf(DefaultS3CrtAsyncClient.class);
-  }
-
-  @Test
-  public void testS3AsyncClientWithCrtDisabled() {
-    assertThat(
-            AwsClientFactories.from(
-                    ImmutableMap.of(
-                        S3FileIOProperties.ACCESS_KEY_ID,
-                        "keyId",
-                        S3FileIOProperties.SECRET_ACCESS_KEY,
-                        "accessKey",
-                        S3FileIOProperties.S3_CRT_ENABLED,
-                        "false",
-                        AwsClientProperties.CLIENT_REGION,
-                        "us-east-1"))
-                .s3Async())
-        .isNotInstanceOf(DefaultS3CrtAsyncClient.class);
-  }
-
-  @Test
-  public void testS3AsyncClientDefaultIsCrt() {
-    assertThat(
-            AwsClientFactories.from(
-                    ImmutableMap.of(
-                        S3FileIOProperties.ACCESS_KEY_ID,
-                        "keyId",
-                        S3FileIOProperties.SECRET_ACCESS_KEY,
-                        "accessKey",
-                        AwsClientProperties.CLIENT_REGION,
-                        "us-east-1"))
-                .s3Async())
-        .isInstanceOf(DefaultS3CrtAsyncClient.class);
   }
 
   @Test
@@ -349,11 +297,6 @@ public class TestAwsClientFactories {
 
     @Override
     public S3Client s3() {
-      return null;
-    }
-
-    @Override
-    public S3AsyncClient s3Async() {
       return null;
     }
 

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/StaticClientFactory.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/StaticClientFactory.java
@@ -23,7 +23,6 @@ import org.apache.iceberg.aws.AwsClientFactory;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.kms.KmsClient;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 class StaticClientFactory implements AwsClientFactory {
@@ -32,11 +31,6 @@ class StaticClientFactory implements AwsClientFactory {
   @Override
   public S3Client s3() {
     return client;
-  }
-
-  @Override
-  public S3AsyncClient s3Async() {
-    return null;
   }
 
   @Override

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestPrefixedS3Client.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestPrefixedS3Client.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import org.apache.iceberg.aws.AwsClientProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @SuppressWarnings("resource")
@@ -33,15 +32,15 @@ public class TestPrefixedS3Client {
 
   @Test
   public void invalidParameters() {
-    assertThatThrownBy(() -> new PrefixedS3Client(null, null, null, null))
+    assertThatThrownBy(() -> new PrefixedS3Client(null, null, null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid storage prefix: null or empty");
 
-    assertThatThrownBy(() -> new PrefixedS3Client("", null, null, null))
+    assertThatThrownBy(() -> new PrefixedS3Client("", null, null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid storage prefix: null or empty");
 
-    assertThatThrownBy(() -> new PrefixedS3Client("s3://bucket", null, null, null))
+    assertThatThrownBy(() -> new PrefixedS3Client("s3://bucket", null, null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid properties: null");
   }
@@ -50,11 +49,10 @@ public class TestPrefixedS3Client {
   public void validParameters() {
     Map<String, String> properties =
         ImmutableMap.of(AwsClientProperties.CLIENT_REGION, "us-east-1");
-    PrefixedS3Client client = new PrefixedS3Client("s3", properties, null, null);
+    PrefixedS3Client client = new PrefixedS3Client("s3", properties, null);
     assertThat(client.storagePrefix()).isEqualTo("s3");
     assertThat(client.s3FileIOProperties().properties())
         .isEqualTo(new S3FileIOProperties(properties).properties());
     assertThat(client.s3()).isInstanceOf(S3Client.class);
-    assertThat(client.s3Async()).isInstanceOf(S3AsyncClient.class);
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -37,7 +37,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryPolicy;
-import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -519,17 +518,12 @@ public class TestS3FileIOProperties {
     properties.put(S3FileIOProperties.ENDPOINT, "endpoint");
     S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
     S3ClientBuilder mockS3ClientBuilder = Mockito.mock(S3ClientBuilder.class);
-    S3AsyncClientBuilder mockS3AsyncClientBuilder = Mockito.mock(S3AsyncClientBuilder.class);
     S3CrtAsyncClientBuilder mockS3CrtAsyncClientBuilder =
         Mockito.mock(S3CrtAsyncClientBuilder.class);
 
     s3FileIOProperties.applyEndpointConfigurations(mockS3ClientBuilder);
-    s3FileIOProperties.applyEndpointConfigurations(mockS3AsyncClientBuilder);
-    s3FileIOProperties.applyEndpointConfigurations(mockS3CrtAsyncClientBuilder);
 
     Mockito.verify(mockS3ClientBuilder).endpointOverride(Mockito.any(URI.class));
-    Mockito.verify(mockS3AsyncClientBuilder).endpointOverride(Mockito.any(URI.class));
-    Mockito.verify(mockS3CrtAsyncClientBuilder).endpointOverride(Mockito.any(URI.class));
   }
 
   @Test


### PR DESCRIPTION
### What Am I doing
Removing the async client which AAL added in pr's:
- https://github.com/apache/iceberg/pull/12553
- https://github.com/apache/iceberg/pull/12299

I am doing this because after testing/benchmarking and speaking with the teams involved, this is not a suitable use-case for the s3 async client so I am removing it.

I am also implementing the range readable interface on the AAL adapter to make better use of the new api's we have added

### How have I tested it
TODO, I still need to update some of the integ/unit tests.